### PR TITLE
Add 'pretty' formatting to displayed CLR Types. See #11

### DIFF
--- a/src/components/Block.vue
+++ b/src/components/Block.vue
@@ -11,11 +11,11 @@
         <span class="namespace">{{ block.Namespace }}</span>
         <h3>{{ block.Name }}</h3>
 
-        <div>
-            <i class="fa fa-sign-in" aria-hidden="true"></i> {{ block.Receives }}
+        <div v-bind:title="block.Receives">
+            <i class="fa fa-sign-in" aria-hidden="true"></i> {{ block.Receives | prettyClrType }}
         </div>
-        <div>
-            <i class="fa fa-sign-out" aria-hidden="true"></i> {{ block.Returns }}
+        <div v-bind:title="block.Returns">
+            <i class="fa fa-sign-out" aria-hidden="true"></i> {{ block.Returns | prettyClrType }}
         </div>
         </b-col>
         </b-row>
@@ -36,12 +36,17 @@
 </template>
 
 <script>
+import { prettyClrType } from "../filters/clrTypes";
+
 export default {
   props: ["blockname"],
   data() {
     return {
       pipelines: []
     };
+  },
+  filters: {
+    prettyClrType
   },
   computed: {
     block: function() {

--- a/src/components/Pipeline.vue
+++ b/src/components/Pipeline.vue
@@ -25,8 +25,8 @@
 
                         <div class="timeline-label">
                             <h3>Start</h3>
-                            <div>
-                                <i class="fa fa-sign-in" aria-hidden="true"></i> {{ pipeline.Receives }}
+                            <div v-bind:title="pipeline.Receives">
+                                <i class="fa fa-sign-in" aria-hidden="true"></i> {{ pipeline.Receives | prettyClrType }}
                             </div>
                         </div>
                     </div>
@@ -47,11 +47,11 @@
                             <div>
                                 <i class="fa fa-cog" aria-hidden="true"></i>
                             </div>
-                            <div>
-                                <i class="fa fa-sign-in" aria-hidden="true"></i> {{ block.Receives }}
+                            <div v-bind:title="block.Receives">
+                                <i class="fa fa-sign-in" aria-hidden="true"></i> {{ block.Receives | prettyClrType }}
                             </div>
-                            <div>
-                                <i class="fa fa-sign-out" aria-hidden="true"></i> {{ block.Returns }}
+                            <div v-bind:title="block.Returns">
+                                <i class="fa fa-sign-out" aria-hidden="true"></i> {{ block.Returns | prettyClrType }}
                             </div>
                         </div>
                     </div>
@@ -68,8 +68,8 @@
 
                         <div class="timeline-label">
                             <h3>Finish</h3>
-                            <div>
-                                <i class="fa fa-sign-out" aria-hidden="true"></i> {{ pipeline.Returns }}
+                            <div v-bind:title="pipeline.Returns">
+                                <i class="fa fa-sign-out" aria-hidden="true"></i> {{ pipeline.Returns | prettyClrType }}
                             </div>
                         </div>
                     </div>
@@ -81,6 +81,8 @@
 </template>
 
 <script>
+import { prettyClrType } from "../filters/clrTypes";
+
 export default {
   name: "Pipeline",
   props: ["pipeline"],
@@ -88,6 +90,9 @@ export default {
     return {
       blocks: []
     };
+  },
+  filters: {
+    prettyClrType
   },
   computed: {
     pipelines: () => {

--- a/src/filters/__tests__/clrTypes.test.js
+++ b/src/filters/__tests__/clrTypes.test.js
@@ -1,0 +1,76 @@
+
+import { prettyClrType, parseClrTypeName } from "../clrTypes";
+
+describe("prettyClrType", () => {
+    test("handles complex acceptance tests", () => {
+        expect(prettyClrType("System.Collections.Generic.IEnumerable`1[[Sitecore.Commerce.Plugin.Shops.Shop, Sitecore.Commerce.Plugin.Shops, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null]]"))
+            .toBe("IEnumerable<Sitecore.Commerce.Plugin.Shops.Shop>")
+
+        expect(prettyClrType("System.Collections.Generic.IDictionary`2[[System.String], [System.Int16]]"))
+            .toBe("IDictionary<string, short>")
+
+        expect(prettyClrType("System.Collections.Generic.IDictionary`2[[Sitecore.Commerce.Plugin.Shops.Shop, Sitecore.Commerce.Plugin.Shops, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null], [Sitecore.Commerce.Plugin.Shops.Shop, Sitecore.Commerce.Plugin.Shops, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null]]"))
+            .toBe("IDictionary<Sitecore.Commerce.Plugin.Shops.Shop, Sitecore.Commerce.Plugin.Shops.Shop>")
+
+        expect(prettyClrType("System.Collections.Generic.IDictionary`2[[System.Int32], [System.Collections.Generic.IDictionary`2[[Sitecore.Commerce.Plugin.Shops.Shop, Sitecore.Commerce.Plugin.Shops, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null], [System.Tuple`2[[System.String], [Sitecore.Commerce.Plugin.Shops.Shop, Sitecore.Commerce.Plugin.Shops, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null]]], [System.Collections.Generic.IDictionary`2[[Sitecore.Commerce.Plugin.Shops.Shop, Sitecore.Commerce.Plugin.Shops, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null], [Sitecore.Commerce.Plugin.Shops.Shop, Sitecore.Commerce.Plugin.Shops, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null]]]]"))
+            .toBe("IDictionary<int, IDictionary<Sitecore.Commerce.Plugin.Shops.Shop, Tuple<string, Sitecore.Commerce.Plugin.Shops.Shop>>>")
+    });
+
+    test("original type is returned for types that throw errors", () => {
+        expect(prettyClrType("Sys?tem.String"))
+            .toBe("Sys?tem.String");
+    });
+});
+
+describe("parseClrTypeName", () => {
+
+    test("unexpected type name characters throw an error", () => {
+        expect(() => parseClrTypeName("Sys?tem.String"))
+            .toThrow()
+    });
+
+    test("fully qualified types have all attributes assigned", () => {
+        expect(parseClrTypeName("Sitecore.Commerce.Plugin.Shops.Shop, Sitecore.Commerce.Plugin.Shops, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null"))
+            .toMatchObject({
+                name: "Sitecore.Commerce.Plugin.Shops.Shop", 
+                assembly: "Sitecore.Commerce.Plugin.Shops", 
+                attributes: {
+                    "Version": "2.0.0.0", 
+                    "Culture": "neutral", 
+                    "PublicKeyToken": "null"
+                }, 
+                genericTypes: []
+            })
+    });
+
+    test("simple qualifed generic type arguments are parsed", () => {
+        expect(parseClrTypeName("System.Collections.Generic.IDictionary`2[System.Int32, System.String]"))
+            .toMatchObject({name: "System.Collections.Generic.IDictionary", assembly: "", attributes: {}, genericTypes: [
+                { name: "System.Int32" },
+                { name: "System.String" }
+            ]})
+    });
+
+    test("fully qualifed generic type arguments are parsed", () => {
+        expect(parseClrTypeName("System.Collections.Generic.IEnumerable`1[[Sitecore.Commerce.Plugin.Shops.Shop, Sitecore.Commerce.Plugin.Shops, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null]]"))
+            .toMatchObject({name: "System.Collections.Generic.IEnumerable", assembly: "", attributes: {}, genericTypes: [
+                { name: "Sitecore.Commerce.Plugin.Shops.Shop", assembly: "Sitecore.Commerce.Plugin.Shops", attributes: { "Version": "2.0.0.0", "Culture": "neutral", "PublicKeyToken": "null" } }
+            ]})
+    });
+
+    test("nested generic type arguments are parsed", () => {
+        expect(parseClrTypeName("System.Collections.Generic.IEnumerable`1[[System.Tuple`2[System.String,[System.Int32]]]]"))
+            .toMatchObject({name: "System.Collections.Generic.IEnumerable", assembly: "", attributes: {}, genericTypes: [
+                { name: "System.Tuple", assembly: "", attributes: {}, genericTypes: [
+                    { name: "System.String" },
+                    { name: "System.Int32" }
+                ]}
+            ]})
+    });
+
+    test("simple type only assigned name", () => {
+        expect(parseClrTypeName("System.String"))
+            .toMatchObject({name: "System.String", assembly: "", attributes: {}, genericTypes: []})
+    });
+
+});

--- a/src/filters/clrTypes.js
+++ b/src/filters/clrTypes.js
@@ -1,0 +1,171 @@
+
+
+export function prettyClrType(typeName) {
+
+    try {
+        var parsedType = parseClrTypeName(typeName);
+
+        return formatClrType(parsedType);
+    } catch (e) {
+        return typeName;
+    }
+}
+
+function formatClrType(parsedType) {
+    var output = formatClrTypeName(parsedType.name);
+
+    if (parsedType.genericTypes.length) {
+        output += "<";
+
+        output += parsedType.genericTypes.map(function(typeArg) {
+            return formatClrType(typeArg)
+        }).join(", ");
+
+        output += ">";
+    }
+
+    return output;
+}
+
+function formatClrTypeName(typeFullName) {
+    var result = /^(\w+(?:\.\w+)*)\.(\w+)$/.exec(typeFullName);
+    var namespace = result[1];
+    var name = result[2];
+
+    // Instrinsic types
+    switch(typeFullName) {
+        case "System.String": return "string";
+        case "System.Byte": return "byte";
+        case "System.Single": return "float";
+        case "System.Double": return "double";
+        case "System.Decimal": return "decimal";
+        case "System.Int16": return "short";
+        case "System.Int32": return "int";
+        case "System.Int64": return "long";
+        case "System.Int16": return "short";
+        case "System.Int32": return "int";
+        case "System.Int64": return "long";
+        case "System.UInt16": return "ushort";
+        case "System.UInt32": return "uint";
+        case "System.UInt64": return "ulong";
+    }
+
+    // Well Known Types
+    switch(typeFullName) {
+        case "System.Threading.Tasks.Task": return "Task";
+    }
+
+    // Generic enumerables
+    if (namespace === "System.Collections.Generic") {
+        return name;
+    } if (namespace === "System") {
+        return name;
+    }
+
+    return typeFullName;
+}
+
+export function parseClrTypeName(typeName) {
+
+  var STATE_QUALIFIED_TYPE = 0;
+  var STATE_SIMPLE_TYPE = 1;
+
+  var STATE_TYPE_NAME = 2;
+  var STATE_TYPE_ASSEMBLY = 3;
+  var STATE_TYPE_ATTRIBUTE_KEY = 4;
+  var STATE_TYPE_ATTRIBUTE_VALUE = 5;
+  var STATE_GENERIC_TYPES = 6;
+
+  // 
+  var states = [STATE_QUALIFIED_TYPE, STATE_TYPE_NAME];
+  var currentState = states[1];
+  
+  var types = [{name: '', assembly: '', attributes: {}, genericTypes: []}];
+  var currentType = types[0];
+  var currentTypeKey = '';
+  
+  for (var index = 0; index < typeName.length; index++) {
+    var char = typeName[index];
+  	
+    if (currentState >= STATE_TYPE_NAME && currentState <= STATE_TYPE_ATTRIBUTE_VALUE) {
+        if (char === '`') {
+            while (/\d/.test(typeName[index+1])) {
+                index++
+            }
+        } else if (/[a-zA-Z\d_\.]/.test(char)) {
+            switch(currentState) {
+                case STATE_TYPE_NAME:
+                    currentType.name += char;
+                    break;
+                case STATE_TYPE_ASSEMBLY:
+                    currentType.assembly += char;
+                    break;
+                case STATE_TYPE_ATTRIBUTE_KEY:
+                    currentTypeKey += char;
+                    break;
+                case STATE_TYPE_ATTRIBUTE_VALUE:
+                    currentType.attributes[currentTypeKey] += char;
+                    break;
+            }
+            
+        } else if (char === ',') {
+
+            if (currentState == STATE_TYPE_ATTRIBUTE_VALUE) {
+                currentState = STATE_TYPE_ATTRIBUTE_KEY;
+            } else if (states.length > 1 && states[states.length - 2] === STATE_QUALIFIED_TYPE) {
+                currentState++;
+            } else if (states.length > 1 && states[states.length - 2] === STATE_SIMPLE_TYPE) {
+                states.pop();
+                states.pop();
+                currentState = states[states.length - 1];
+                types.pop();
+                currentType = types[types.length - 1];
+            }
+
+            if (currentState === STATE_TYPE_ATTRIBUTE_KEY) {
+                currentTypeKey = '';
+            }
+        } else if (/\w/.test(char) || char === ' ') {
+            // ignore
+        } else if (char === ']') {
+            states.pop();
+            states.pop();
+            currentState = states[states.length - 1];
+            types.pop();
+            currentType = types[types.length - 1];
+        } else if (char === '[') {
+            if (currentType.name !== '') {
+                currentState = STATE_GENERIC_TYPES;
+                states[states.length-1] = STATE_GENERIC_TYPES;
+            }
+        } else if (char === '=' && currentState === STATE_TYPE_ATTRIBUTE_KEY) {
+            currentState = STATE_TYPE_ATTRIBUTE_VALUE;
+
+            currentType.attributes[currentTypeKey] = '';
+        } else {
+            throw "Unexpected type name char '" + char + "' at position " + index;
+        }
+    } else if (currentState === STATE_GENERIC_TYPES) {
+        if (/[a-zA-Z\d_\[]/.test(char)) {
+            states.push(char === '[' ? STATE_QUALIFIED_TYPE : STATE_SIMPLE_TYPE);
+            states.push(currentState = STATE_TYPE_NAME);
+
+            var newType = {name: '', assembly: '', attributes: {}, genericTypes: []};
+
+            currentType.genericTypes.push(newType);
+
+            types.push(currentType = newType)
+
+            if (char !== '[') {
+                currentType.name += char;
+            }
+        } else if (char === ']') {
+            states.pop();
+            currentState = states[states.length - 1];
+        }
+      }
+
+    }
+    
+    return types[0];
+  }


### PR DESCRIPTION
This PR includes pretty formatting for CLR types to improve their readability. The change affects the display of both Blocks and Pipelines. I've not included anyway of toggling/disabling the functionality, but the original value is left in as a tooltip.

The included tests are quite high "coverage", but there are a few implemented conditions that I'm not testing - I might submit a few more tests in the future. There's also no tests for _malformed_ CLR types, since I decided not to support them (these are being generated by .NET, after all)

